### PR TITLE
Expand env variables in substitutions paths

### DIFF
--- a/build/build_dependency_files.py
+++ b/build/build_dependency_files.py
@@ -36,6 +36,7 @@ seen_deps = []
 def add_subs_module(srcbase, module, filepath, subs_dict):
     if filepath:
         fullpath = os.path.join(srcbase, filepath.strip())
+        fullpath = os.path.expandvars(fullpath)
         subs_dict[module.strip()] = fullpath
     else:
         # No path means remove module

--- a/examples/example-subs.yml
+++ b/examples/example-subs.yml
@@ -8,3 +8,8 @@ bad_mod:
 include:
   - chip/a10_substitutions.yml
   - chip/s10_substitutions.yml
+
+# Use environment variables to build path
+# variables set in makefile must have 'export' in front of them
+ip_core: path/off/SRC_BASE_DIR/$VIVADO_VERSION/ip_core.xci
+ip_core_2: path/off/SRC_BASE_DIR/$DEVICE/ip_core_2.xci

--- a/examples/example-subs.yml
+++ b/examples/example-subs.yml
@@ -4,12 +4,12 @@ modulename: path/off/SRC_BASE_DIR/modulev1.sv
 # Empty assignment means leave module out of project
 bad_mod:
 
-# Include other yaml files
-include:
-  - chip/a10_substitutions.yml
-  - chip/s10_substitutions.yml
-
 # Use environment variables to build path
 # variables set in makefile must have 'export' in front of them
 ip_core: path/off/SRC_BASE_DIR/$VIVADO_VERSION/ip_core.xci
 ip_core_2: path/off/SRC_BASE_DIR/$DEVICE/ip_core_2.xci
+
+# Include other yaml files
+include:
+  - chip/a10_substitutions.yml
+  - chip/s10_substitutions.yml


### PR DESCRIPTION
Expand environment variables in yaml IP paths. This enables users to have multiple versions of IP files depending on version, device, or any other variable.